### PR TITLE
fallback to offset calculation if it does not exist

### DIFF
--- a/index.html
+++ b/index.html
@@ -215,8 +215,8 @@ function displayNextObject(){
 	}else{
 		objectQueue[0].paperimage.show();
 		objectQueue[0].paperimage.click(function(evt){
-			var x = evt.offsetX;
-			var y = evt.offsetY;
+            var x  = (evt.offsetX || evt.clientX - $(evt.target).offset().left);
+            var y  = (evt.offsetY || evt.clientY - $(evt.target).offset().top);
 			faceTapped(x,y);
 
 		});	


### PR DESCRIPTION
had trouble testing locally, but this should at the very least not change any behavior if the current browser has a defined offsetX/offsetY property.
